### PR TITLE
A TOTP (RFC 6238) implementation

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -105,7 +105,7 @@ It's worth to note that the hash is also upgraded if the **settings of the algor
 
 ## TOTP
 
-To provide a second factor of authentication, `pwdlib` exposes the [`TOTP`](./reference/pwd.totp.md#pwdlib.totp.TOTP) class.
+To provide a second factor of authentication, `pwdlib` exposes the [`TOTP`](./reference/pwdlib.totp.md#pwdlib.totp.TOTP) class.
 
 ```py
 from pwdlib import totp

--- a/docs/reference/pwdlib.totp.md
+++ b/docs/reference/pwdlib.totp.md
@@ -1,0 +1,6 @@
+# Reference - TOTP
+
+::: pwdlib.totp
+    options:
+      show_root_heading: false
+      show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,3 +69,4 @@ nav:
         - pwdlib: reference/pwdlib.md
         - pwdlib.exceptions: reference/pwdlib.exceptions.md
         - pwdlib.hashers: reference/pwdlib.hashers.md
+        - pwdlib.totp: reference/pwdlib.totp.md

--- a/pwdlib/exceptions.py
+++ b/pwdlib/exceptions.py
@@ -53,3 +53,16 @@ class UnknownHashError(PwdlibError):
             "Make sure it's valid and that its corresponding hasher is enabled."
         )
         super().__init__(message)
+
+
+class UnknownHashAlgorithmError(PwdlibError):
+    """Raised if the named hash algorithm was not recognised."""
+
+    def __init__(self, alg: str):
+        """
+        Args:
+            alg: Hash algorithm name given
+        """
+        self.alg = alg
+        message = f"'{alg}' is not a supported TOTP hash algorithm"
+        super().__init__(message)

--- a/pwdlib/totp.py
+++ b/pwdlib/totp.py
@@ -1,0 +1,136 @@
+import base64
+import hmac
+import secrets
+import struct
+import time as _time
+import typing as t
+import urllib.parse as _parse
+
+from .exceptions import UnknownHashAlgorithmError
+
+_allowed_hashes = ["sha1", "sha256", "sha512"]
+
+_pack_uint64 = struct.Struct(">Q").pack
+_unpack_uint32 = struct.Struct(">I").unpack
+
+
+class TOTP:
+    """An implementation of TOTP (RFC 6238)."""
+
+    def __init__(
+        self,
+        key: t.Optional[bytes] = None,
+        *,
+        alg: str = "sha1",
+        digits: int = 6,
+        period: int = 30,
+        key_size: int = 16,
+    ) -> None:
+        """
+        Args:
+            key: A buffer of random bytes acting as a key. Will be generated if None.
+            alg: Hash algorithm to use for the OTP. Defaults to "sha1", but supports sha256 and sha512.
+            digits: Length of the OTP. Defaults to 6 digits.
+            period: Validity period in seconds of the OTP. Defaults to 30.
+            key_size: If no key is given, the length in bytes of the key go generate. Default to 16.
+
+        Raises:
+            UnknownHashAlgorithmError: If the hash algorithm given is not recognised.
+        """
+        if alg not in _allowed_hashes:
+            raise UnknownHashAlgorithmError(alg)
+        if key is None:
+            key = secrets.token_bytes(key_size)
+        self.alg = alg
+        self.key = key
+        self.digits = digits
+        self.period = period
+
+    def to_dict(self) -> dict:
+        """Write the state to a dictionary for serialisation."""
+        return {
+            "alg": self.alg,
+            "key": base64.b64encode(self.key).decode("ascii"),
+            "digits": self.digits,
+            "period": self.period,
+        }
+
+    @classmethod
+    def from_dict(cls, src: dict) -> "TOTP":
+        """Extract the state from a dictionary."""
+        return cls(
+            alg=src["alg"],
+            key=base64.b64decode(src["key"].encode("ascii")),
+            digits=src["digits"],
+            period=src["period"],
+        )
+
+    def to_url(self, account_name: str, issuer: t.Optional[str] = None) -> str:
+        """Convert the object to a Google Authenticator key URI.
+
+        Args:
+            account_name: The user's account name.
+            issuer: The name of the issuer.
+
+        Returns:
+            An OTP key URI.
+        """
+        result = ["otpauth://totp/"]
+        params = {
+            "secret": base64.b32encode(self.key).decode("ascii").rstrip("="),
+            "algorithm": self.alg.upper(),
+            "digits": self.digits,
+            "period": self.period,
+        }
+        if issuer is not None:
+            result.append(_parse.quote(issuer) + ":")
+            params["issuer"] = issuer
+        result.append(_parse.quote(account_name) + "?")
+        result.append(_parse.urlencode(params))
+        return "".join(result)
+
+    def _normalise(self, now: int) -> int:
+        return now // self.period
+
+    def _generate(self, now: int) -> str:
+        packed = _pack_uint64(now)
+        digest = hmac.new(
+            key=self.key,
+            msg=packed,
+            digestmod=self.alg,
+        ).digest()
+        offset = digest[-1] & 0xF
+        value = _unpack_uint32(digest[offset : offset + 4])[0] & 0x7FFFFFFF
+        return f"{value:0>{self.digits}}"[-self.digits :]
+
+    def generate(self, now: t.Optional[int] = None) -> str:
+        """Generate a TOTP.
+
+        Args:
+            now: A Unix timestamp. Defaults to the current time.
+
+        Returns:
+            The TOTP.
+        """
+        if now is None:
+            now = int(_time.time())
+        return self._generate(self._normalise(now))
+
+    def check(self, otp: str, *, window: int = 2, now: t.Optional[int] = None) -> bool:
+        """Check a TOTP against the current expected TOTP and the previous one.
+
+        Args:
+            otp: OTP to check.
+            window: Number of windows back in time to use when checking checking the OTP.
+            now: A Unix timestamp. Defaults to the current time.
+
+        Return:
+            True if the OTP matched, False otherwise.
+        """
+        if now is None:
+            now = int(_time.time())
+        normalised_now = self._normalise(now)
+        for i in range(0, window):
+            if secrets.compare_digest(otp, self._generate(normalised_now - i)):
+                return True
+        return False

--- a/pwdlib/totp.py
+++ b/pwdlib/totp.py
@@ -124,7 +124,7 @@ class TOTP:
             window: Number of windows back in time to use when checking checking the OTP.
             now: A Unix timestamp. Defaults to the current time.
 
-        Return:
+        Returns:
             True if the OTP matched, False otherwise.
         """
         if now is None:

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -1,0 +1,138 @@
+from urllib import parse
+
+import pytest
+
+from pwdlib import totp
+
+
+def test_otp_key_url():
+    t = totp.TOTP(key=bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+    parts = t.to_url("foo@example.com").split("?", 1)
+    assert parts[0] == "otpauth://totp/foo%40example.com"
+    qs = parse.parse_qs(parts[1])
+    assert qs == {
+        "secret": ["AAAAAAAAAAAAAAAA"],
+        "algorithm": ["SHA1"],
+        "digits": ["6"],
+        "period": ["30"],
+    }
+
+
+def test_otp_key_url_with_issuer():
+    t = totp.TOTP(key=bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+    parts = t.to_url("foo@example.com", issuer="Yoyodyne Systems").split("?", 1)
+    assert parts[0] == "otpauth://totp/Yoyodyne%20Systems:foo%40example.com"
+    qs = parse.parse_qs(parts[1])
+    assert qs == {
+        "secret": ["AAAAAAAAAAAAAAAA"],
+        "algorithm": ["SHA1"],
+        "digits": ["6"],
+        "period": ["30"],
+        "issuer": ["Yoyodyne Systems"],
+    }
+
+
+def test_serialisation():
+    t1 = totp.TOTP(key=bytes(range(0, 10)), alg="sha256", digits=10, period=60)
+    d = t1.to_dict()
+    assert d == {
+        "alg": "sha256",
+        "digits": 10,
+        "key": "AAECAwQFBgcICQ==",
+        "period": 60,
+    }
+    t2 = totp.TOTP.from_dict(d)
+    assert t1.key == t2.key
+    assert t1.alg == t2.alg
+    assert t1.digits == t2.digits
+    assert t1.period == t2.period
+
+
+def test_bad_algorithm():
+    with pytest.raises(totp.UnknownHashAlgorithmError):
+        totp.TOTP(alg="foo")
+
+
+def test_key_generated():
+    t = totp.TOTP()
+    assert isinstance(t.key, bytes)
+
+
+def test_validity():
+    t = totp.TOTP()
+    assert t.check(t.generate())
+
+
+def test_failure():
+    t = totp.TOTP(period=5)
+    now = 123456780
+    otp = t.generate(now=now)
+    assert t.check(otp, window=1, now=now)
+    # Just shy of the window...
+    assert t.check(otp, window=1, now=now + 4)
+    # Past the window.
+    assert not t.check(otp, window=1, now=now + 5)
+
+
+def check_vector(key: bytes, alg: str, now: int, expected: str):
+    assert totp.TOTP(key=key, alg=alg, digits=8, period=30).generate(now) == expected
+
+
+@pytest.mark.parametrize(
+    "now,expected",
+    [
+        (59, "94287082"),
+        (1111111109, "07081804"),
+        (1111111111, "14050471"),
+        (1234567890, "89005924"),
+        (2000000000, "69279037"),
+        (20000000000, "65353130"),
+    ],
+)
+def test_sha1_vectors(now: int, expected: str):
+    check_vector(
+        b"12345678901234567890",
+        "sha1",
+        now,
+        expected,
+    )
+
+
+@pytest.mark.parametrize(
+    "now,expected",
+    [
+        (59, "46119246"),
+        (1111111109, "68084774"),
+        (1111111111, "67062674"),
+        (1234567890, "91819424"),
+        (2000000000, "90698825"),
+        (20000000000, "77737706"),
+    ],
+)
+def test_sha256_vectors(now: int, expected: str):
+    check_vector(
+        b"12345678901234567890123456789012",
+        "sha256",
+        now,
+        expected,
+    )
+
+
+@pytest.mark.parametrize(
+    "now,expected",
+    [
+        (59, "90693936"),
+        (1111111109, "25091201"),
+        (1111111111, "99943326"),
+        (1234567890, "93441116"),
+        (2000000000, "38618901"),
+        (20000000000, "47863826"),
+    ],
+)
+def test_sha512_vectors(now: int, expected: str):
+    check_vector(
+        b"1234567890123456789012345678901234567890123456789012345678901234",
+        "sha512",
+        now,
+        expected,
+    )


### PR DESCRIPTION
I had been using the TOTP implementation in passlib previously, but given it's essentially on life support, I figured it'd be worth writing my own implementation to avoid future breakage. It's not API compatible with passlib's implementation, but should be easy enough to adapt any existing implementation to use this instead.

While I debated whether or not to make SHA-1 the default hash, I decided to stick with it because some prominent TOTP applications (such as Google Authenticator last time I looked) only support it.