### PR TITLE
feat: apply future style type hints to support py3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python_version: ["3.10", "3.11", "3.12", "3.13"]
+                python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
         steps:
             - uses: actions/checkout@v5
@@ -15,6 +15,7 @@ jobs:
               uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python_version }}
+                  allow-prereleases: true
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip

--- a/pwdlib/_hash.py
+++ b/pwdlib/_hash.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections.abc
 
 from . import exceptions
@@ -22,7 +24,7 @@ class PasswordHash:
         self.current_hasher = hashers[0]
 
     @classmethod
-    def recommended(cls) -> "PasswordHash":
+    def recommended(cls) -> PasswordHash:
         """
         Returns a PasswordHash instance with recommended hashers.
 

--- a/pwdlib/exceptions.py
+++ b/pwdlib/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class PwdlibError(Exception):
     """
     Base pwdlib error.

--- a/pwdlib/hashers/argon2.py
+++ b/pwdlib/hashers/argon2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     import argon2.exceptions
     from argon2 import PasswordHasher

--- a/pwdlib/hashers/base.py
+++ b/pwdlib/hashers/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 
 

--- a/pwdlib/hashers/bcrypt.py
+++ b/pwdlib/hashers/bcrypt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import typing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py310"
+target-version = "py39"
 
 [tool.ruff.lint]
 extend-select = ["I", "TRY", "UP"]
@@ -67,13 +67,15 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Security",
     "Topic :: Security :: Cryptography",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
 
 ]

--- a/tests/hashers/test_argon2.py
+++ b/tests/hashers/test_argon2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pwdlib.hashers.argon2 import Argon2Hasher

--- a/tests/hashers/test_bcrypt.py
+++ b/tests/hashers/test_bcrypt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pwdlib.hashers.bcrypt import BcryptHasher

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pwdlib import PasswordHash, exceptions


### PR DESCRIPTION
# Description

1. Use `from __future__ import annotations` to support `X | Y` type hints for Python3.9
2. Add py3.14 to ci list