### PR TITLE
Fix mkdocstrings config for newer versions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ plugins:
     - mkdocstrings:
           handlers:
               python:
-                  import:
+                  inventories:
                       - https://docs.python.org/3.10/objects.inv
                   options:
                       docstring_style: google


### PR DESCRIPTION
MkDocs builds were failing because the import: key is no longer supported by recent mkdocstrings-python releases[1].
Replaced it with the valid inventories: option to restore documentation build compatibility.

[1] https://mkdocstrings.github.io/python/usage/?h=inven#inventories