### PR TITLE
docs: clarify what happens when salt=None

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -67,7 +67,11 @@ The resulting string is a hash generated from the **current algorithm**, which y
 
 !!! question "Where is the salt?"
 
-    If you know about password hashing algorithms, you probably know that *salting* the password is an important security feature. Back in the days, it was common to store the salt separately from the hash. Nowadays, most algorithms have a specific structure allowing them to store algorithm parameters and salt along with the hash in one string.
+    If you know about password hashing algorithms, you probably know that *salting* the password is an important security feature.
+
+    By default, `hash()` chooses a salt for you.
+
+    Back in the days, it was common to store the salt separately from the hash. Nowadays, most algorithms have a specific structure allowing them to store algorithm parameters and salt along with the hash in one string.
 
     For example, here is an Argon2 hash:
 

--- a/pwdlib/_hash.py
+++ b/pwdlib/_hash.py
@@ -45,7 +45,7 @@ class PasswordHash:
 
         Args:
             password: The password to be hashed.
-            salt: The salt to be used for hashing. Defaults to None.
+            salt: The salt to be used for hashing. If set to `None`, a random salt is used.
 
         Returns:
             The hashed password.


### PR DESCRIPTION
When calling `hash()`, I wasn't sure if leaving out the `salt` argument would autogenerate a salt, or use no salt. It looks like it autogenerates a salt, so this documents that.