### PR TITLE
Add ScryptHasher using Python's builtin hashlib.scrypt

### DIFF
--- a/pwdlib/hashers/__init__.py
+++ b/pwdlib/hashers/__init__.py
@@ -1,6 +1,3 @@
-from .argon2 import Argon2Hasher
 from .base import HasherProtocol
-from .bcrypt import BcryptHasher
-from .scrypt import ScryptHasher
 
-__all__ = ["HasherProtocol", "Argon2Hasher", "BcryptHasher", "ScryptHasher"]
+__all__ = ["HasherProtocol"]

--- a/pwdlib/hashers/__init__.py
+++ b/pwdlib/hashers/__init__.py
@@ -1,3 +1,6 @@
+from .argon2 import Argon2Hasher
 from .base import HasherProtocol
+from .bcrypt import BcryptHasher
+from .scrypt import ScryptHasher
 
-__all__ = ["HasherProtocol"]
+__all__ = ["HasherProtocol", "Argon2Hasher", "BcryptHasher", "ScryptHasher"]

--- a/pwdlib/hashers/scrypt.py
+++ b/pwdlib/hashers/scrypt.py
@@ -91,9 +91,10 @@ class ScryptHasher(HasherProtocol):
 
         if salt is None:
             salt = os.urandom(self.salt_len)
-
-        # Ensure salt is the correct length
-        salt = salt[: self.salt_len]
+        elif len(salt) != self.salt_len:
+            raise ValueError(
+                f"salt must be exactly {self.salt_len} bytes long"
+            )
 
         # Generate the scrypt hash
         derived_key = hashlib.scrypt(

--- a/pwdlib/hashers/scrypt.py
+++ b/pwdlib/hashers/scrypt.py
@@ -92,7 +92,7 @@ class ScryptHasher(HasherProtocol):
             salt = os.urandom(self.salt_len)
         elif len(salt) != self.salt_len:
             raise ValueError(
-                f"salt must be exactly {self.salt_len} bytes long"
+                f"salt must be exactly {self.salt_len} bytes long, got {len(salt)}"
             )
 
         # Generate the scrypt hash

--- a/pwdlib/hashers/scrypt.py
+++ b/pwdlib/hashers/scrypt.py
@@ -1,5 +1,7 @@
 import base64
+import binascii
 import hashlib
+import hmac
 import os
 import re
 
@@ -156,8 +158,8 @@ class ScryptHasher(HasherProtocol):
             )
 
             # Use constant-time comparison
-            return derived_key == expected_hash
-        except (ValueError, TypeError):
+            return hmac.compare_digest(derived_key, expected_hash)
+        except (ValueError, TypeError, binascii.Error):
             return False
 
     def check_needs_rehash(self, hash: str | bytes) -> bool:

--- a/pwdlib/hashers/scrypt.py
+++ b/pwdlib/hashers/scrypt.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import os
 import re
-import typing
 
 from .base import HasherProtocol, ensure_bytes, ensure_str, validate_str_or_bytes
 

--- a/pwdlib/hashers/scrypt.py
+++ b/pwdlib/hashers/scrypt.py
@@ -1,0 +1,191 @@
+import base64
+import hashlib
+import os
+import re
+import typing
+
+from .base import HasherProtocol, ensure_bytes, ensure_str, validate_str_or_bytes
+
+# OWASP recommended parameters for scrypt
+# https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#scrypt
+DEFAULT_N = 2**14  # CPU/memory cost parameter (16384)
+DEFAULT_R = 8  # Block size parameter
+DEFAULT_P = 1  # Parallelization parameter
+DEFAULT_SALT_LEN = 16  # 16 bytes = 128 bits
+DEFAULT_HASH_LEN = 64  # 64 bytes = 512 bits
+
+# Pattern for identifying scrypt hashes
+# Format: $scrypt$<N>$<salt>$<r>$<p>$<hash>
+# Following Django's format: https://github.com/django/django/blob/main/django/contrib/auth/hashers.py
+# Using standard base64 for salt and hash (can contain / and =)
+SCRYPT_ENCODED_HASH_REGEX: re.Pattern = re.compile(
+    r"^\$scrypt\$(\d+)\$([A-Za-z0-9+/=]+)\$(\d+)\$(\d+)\$([A-Za-z0-9+/=]+)$"
+)
+
+
+class ScryptHasher(HasherProtocol):
+    """
+    Scrypt password hasher using Python's builtin hashlib.scrypt.
+
+    Follows OWASP recommendations for parameters:
+    - N (CPU/memory cost): 2^14 (16384)
+    - r (block size): 8
+    - p (parallelization): 1
+
+    Hash format: $scrypt$<N>$<salt>$<r>$<p>$<hash>
+    All components are base64-encoded except N, r, p which are integers.
+    """
+
+    def __init__(
+        self,
+        n: int = DEFAULT_N,
+        r: int = DEFAULT_R,
+        p: int = DEFAULT_P,
+        salt_len: int = DEFAULT_SALT_LEN,
+        hash_len: int = DEFAULT_HASH_LEN,
+    ) -> None:
+        """
+        Args:
+            n: CPU/memory cost parameter (must be a power of 2, >= 2).
+            r: Block size parameter.
+            p: Parallelization parameter.
+            salt_len: Length of the random salt in bytes.
+            hash_len: Length of the derived key in bytes.
+        """
+        self.n = n
+        self.r = r
+        self.p = p
+        self.salt_len = salt_len
+        self.hash_len = hash_len
+
+    @classmethod
+    def identify(cls, hash: str | bytes) -> bool:
+        """
+        Identify if the given hash is a scrypt hash.
+
+        Args:
+            hash: The hash to identify.
+
+        Returns:
+            True if the hash matches the scrypt format, False otherwise.
+        """
+        validate_str_or_bytes(hash, "hash")
+        try:
+            hash_str = ensure_str(hash)
+        except UnicodeDecodeError:
+            return False
+        return SCRYPT_ENCODED_HASH_REGEX.fullmatch(hash_str) is not None
+
+    def hash(self, password: str | bytes, *, salt: bytes | None = None) -> str:
+        """
+        Hash a password using scrypt.
+
+        Args:
+            password: The password to hash.
+            salt: Optional salt bytes. If None, a random salt will be generated.
+
+        Returns:
+            The encoded hash string in the format: $scrypt$<N>$<salt>$<r>$<p>$<hash>
+        """
+        validate_str_or_bytes(password, "password")
+
+        if salt is None:
+            salt = os.urandom(self.salt_len)
+
+        # Ensure salt is the correct length
+        salt = salt[: self.salt_len]
+
+        # Generate the scrypt hash
+        derived_key = hashlib.scrypt(
+            password=ensure_bytes(password),
+            salt=salt,
+            n=self.n,
+            r=self.r,
+            p=self.p,
+            dklen=self.hash_len,
+        )
+
+        # Encode salt and hash in standard base64 (with padding)
+        salt_b64 = base64.b64encode(salt).decode("ascii")
+        hash_b64 = base64.b64encode(derived_key).decode("ascii")
+
+        return f"$scrypt${self.n}${salt_b64}${self.r}${self.p}${hash_b64}"
+
+    def verify(self, password: str | bytes, hash: str | bytes) -> bool:
+        """
+        Verify a password against a scrypt hash.
+
+        Args:
+            password: The password to verify.
+            hash: The stored hash to verify against.
+
+        Returns:
+            True if the password matches the hash, False otherwise.
+        """
+        validate_str_or_bytes(password, "password")
+        validate_str_or_bytes(hash, "hash")
+
+        try:
+            hash_str = ensure_str(hash)
+        except UnicodeDecodeError:
+            return False
+
+        match = SCRYPT_ENCODED_HASH_REGEX.fullmatch(hash_str)
+        if match is None:
+            return False
+
+        try:
+            n = int(match.group(1))
+            salt_b64 = match.group(2)
+            r = int(match.group(3))
+            p = int(match.group(4))
+            expected_hash_b64 = match.group(5)
+
+            # Decode salt and expected hash (standard base64)
+            salt = base64.b64decode(salt_b64)
+            expected_hash = base64.b64decode(expected_hash_b64)
+
+            # Recompute the hash with the same parameters
+            derived_key = hashlib.scrypt(
+                password=ensure_bytes(password),
+                salt=salt,
+                n=n,
+                r=r,
+                p=p,
+                dklen=len(expected_hash),
+            )
+
+            # Use constant-time comparison
+            return derived_key == expected_hash
+        except (ValueError, TypeError):
+            return False
+
+    def check_needs_rehash(self, hash: str | bytes) -> bool:
+        """
+        Check if a hash needs to be rehashed with the current parameters.
+
+        Args:
+            hash: The hash to check.
+
+        Returns:
+            True if the hash parameters differ from the current configuration.
+        """
+        validate_str_or_bytes(hash, "hash")
+
+        try:
+            hash_str = ensure_str(hash)
+        except UnicodeDecodeError:
+            return True
+
+        match = SCRYPT_ENCODED_HASH_REGEX.fullmatch(hash_str)
+        if match is None:
+            return True
+
+        try:
+            n = int(match.group(1))
+            r = int(match.group(3))
+            p = int(match.group(4))
+
+            return n != self.n or r != self.r or p != self.p
+        except (ValueError, TypeError):
+            return True

--- a/tests/hashers/test_scrypt.py
+++ b/tests/hashers/test_scrypt.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+
 import pytest
 
 from pwdlib.hashers.scrypt import ScryptHasher
@@ -26,9 +27,21 @@ def scrypt_hasher_custom_params() -> ScryptHasher:
     [
         pytest.param(_HASH_STR, True, id="identify(valid_scrypt_hash: str)"),
         pytest.param(_HASH_BYTES, True, id="identify(valid_scrypt_hash: bytes)"),
-        pytest.param("$scrypt$16384$invalid$8$1", False, id="identify(invalid_scrypt_hash: wrong_format)"),
-        pytest.param("$bcrypt$12$N9Zh0y3G.3yBxRlA57Wo1O3TEmZBx2SF5N2P0t3jOTuK./Ko8dH3u", False, id="identify(bcrypt_hash)"),
-        pytest.param("$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$Hnm7B2p4pnTo3mQ5qFmnHjR1OZBtVXd1B33joTc/XXg", False, id="identify(argon2_hash)"),
+        pytest.param(
+            "$scrypt$16384$invalid$8$1",
+            False,
+            id="identify(invalid_scrypt_hash: wrong_format)",
+        ),
+        pytest.param(
+            "$bcrypt$12$N9Zh0y3G.3yBxRlA57Wo1O3TEmZBx2SF5N2P0t3jOTuK./Ko8dH3u",
+            False,
+            id="identify(bcrypt_hash)",
+        ),
+        pytest.param(
+            "$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$Hnm7B2p4pnTo3mQ5qFmnHjR1OZBtVXd1B33joTc/XXg",
+            False,
+            id="identify(argon2_hash)",
+        ),
         pytest.param("", False, id="identify(empty_string: str)"),
         pytest.param(b"", False, id="identify(empty_string: bytes)"),
     ],
@@ -93,6 +106,14 @@ def test_verify_invalid_hash_format(scrypt_hasher: ScryptHasher) -> None:
     assert not scrypt_hasher.verify(_PASSWORD, b"INVALID_HASH")
 
 
+def test_verify_malformed_base64(scrypt_hasher: ScryptHasher) -> None:
+    """Test that verify returns False for hashes with invalid base64 encoding."""
+    # Hash that matches the regex but has invalid base64 (bad padding)
+    malformed_hash = "$scrypt$16384$invalid!!!base64$8$1$invalid!!!base64"
+    assert not scrypt_hasher.verify(_PASSWORD, malformed_hash)
+    assert not scrypt_hasher.verify(_PASSWORD, malformed_hash.encode("ascii"))
+
+
 def test_check_needs_rehash(scrypt_hasher: ScryptHasher) -> None:
     # Hash with default params should not need rehash
     hash = scrypt_hasher.hash(_PASSWORD)
@@ -100,7 +121,9 @@ def test_check_needs_rehash(scrypt_hasher: ScryptHasher) -> None:
     assert not scrypt_hasher.check_needs_rehash(hash.encode("ascii"))
 
 
-def test_check_needs_rehash_different_params(scrypt_hasher: ScryptHasher, scrypt_hasher_custom_params: ScryptHasher) -> None:
+def test_check_needs_rehash_different_params(
+    scrypt_hasher: ScryptHasher, scrypt_hasher_custom_params: ScryptHasher
+) -> None:
     # Hash with custom params should need rehash when checked with default params
     hash = scrypt_hasher_custom_params.hash(_PASSWORD)
     assert scrypt_hasher.check_needs_rehash(hash)
@@ -150,7 +173,6 @@ def test_hash_format(scrypt_hasher: ScryptHasher) -> None:
 
     # Check that salt and hash are valid base64
     salt_b64 = parts[3]
-    hash_b64 = parts[6]
 
     # The salt should be base64 decodable
     salt = base64.b64decode(salt_b64)

--- a/tests/hashers/test_scrypt.py
+++ b/tests/hashers/test_scrypt.py
@@ -52,15 +52,15 @@ def test_hash_with_custom_salt(scrypt_hasher: ScryptHasher) -> None:
 
 
 def test_hash_deterministic_with_same_salt(scrypt_hasher: ScryptHasher) -> None:
-    custom_salt = b"fixedsalt12345678"
+    custom_salt = b"fixedsalt1234567"
     hash1 = scrypt_hasher.hash(_PASSWORD, salt=custom_salt)
     hash2 = scrypt_hasher.hash(_PASSWORD, salt=custom_salt)
     assert hash1 == hash2
 
 
 def test_hash_different_with_different_salt(scrypt_hasher: ScryptHasher) -> None:
-    hash1 = scrypt_hasher.hash(_PASSWORD, salt=b"salt1")
-    hash2 = scrypt_hasher.hash(_PASSWORD, salt=b"salt2")
+    hash1 = scrypt_hasher.hash(_PASSWORD, salt=b"salt1xxxxxxxxxxx")
+    hash2 = scrypt_hasher.hash(_PASSWORD, salt=b"salt2xxxxxxxxxxx")
     assert hash1 != hash2
 
 
@@ -160,7 +160,7 @@ def test_hash_format(scrypt_hasher: ScryptHasher) -> None:
 def test_verify_manual_hash(scrypt_hasher: ScryptHasher) -> None:
     """Test verification with a manually constructed hash."""
     password = "test123"
-    salt = b"manuelsalt1234"
+    salt = b"manuelsalt123456"
 
     # Create hash manually
     derived_key = hashlib.scrypt(

--- a/tests/hashers/test_scrypt.py
+++ b/tests/hashers/test_scrypt.py
@@ -1,0 +1,181 @@
+import base64
+import hashlib
+import pytest
+
+from pwdlib.hashers.scrypt import ScryptHasher
+
+_PASSWORD = "testpassword123"
+
+_HASHER = ScryptHasher()
+_HASH_STR = _HASHER.hash(_PASSWORD)
+_HASH_BYTES = _HASH_STR.encode("ascii")
+
+
+@pytest.fixture
+def scrypt_hasher() -> ScryptHasher:
+    return ScryptHasher()
+
+
+@pytest.fixture
+def scrypt_hasher_custom_params() -> ScryptHasher:
+    return ScryptHasher(n=2**10, r=4, p=1)
+
+
+@pytest.mark.parametrize(
+    "hash,result",
+    [
+        pytest.param(_HASH_STR, True, id="identify(valid_scrypt_hash: str)"),
+        pytest.param(_HASH_BYTES, True, id="identify(valid_scrypt_hash: bytes)"),
+        pytest.param("$scrypt$16384$invalid$8$1", False, id="identify(invalid_scrypt_hash: wrong_format)"),
+        pytest.param("$bcrypt$12$N9Zh0y3G.3yBxRlA57Wo1O3TEmZBx2SF5N2P0t3jOTuK./Ko8dH3u", False, id="identify(bcrypt_hash)"),
+        pytest.param("$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$Hnm7B2p4pnTo3mQ5qFmnHjR1OZBtVXd1B33joTc/XXg", False, id="identify(argon2_hash)"),
+        pytest.param("", False, id="identify(empty_string: str)"),
+        pytest.param(b"", False, id="identify(empty_string: bytes)"),
+    ],
+)
+def test_identify(hash: str | bytes, result: bool) -> None:
+    assert ScryptHasher.identify(hash) == result
+
+
+def test_hash(scrypt_hasher: ScryptHasher) -> None:
+    hash = scrypt_hasher.hash("testpassword123")
+    assert isinstance(hash, str)
+    assert hash.startswith("$scrypt$")
+    assert ScryptHasher.identify(hash)
+
+
+def test_hash_with_custom_salt(scrypt_hasher: ScryptHasher) -> None:
+    custom_salt = b"customsalt123456"
+    hash = scrypt_hasher.hash(_PASSWORD, salt=custom_salt)
+    assert isinstance(hash, str)
+    assert ScryptHasher.identify(hash)
+
+
+def test_hash_deterministic_with_same_salt(scrypt_hasher: ScryptHasher) -> None:
+    custom_salt = b"fixedsalt12345678"
+    hash1 = scrypt_hasher.hash(_PASSWORD, salt=custom_salt)
+    hash2 = scrypt_hasher.hash(_PASSWORD, salt=custom_salt)
+    assert hash1 == hash2
+
+
+def test_hash_different_with_different_salt(scrypt_hasher: ScryptHasher) -> None:
+    hash1 = scrypt_hasher.hash(_PASSWORD, salt=b"salt1")
+    hash2 = scrypt_hasher.hash(_PASSWORD, salt=b"salt2")
+    assert hash1 != hash2
+
+
+@pytest.mark.parametrize(
+    "hash,password,result",
+    [
+        (_HASH_STR, _PASSWORD, True),
+        (_HASH_BYTES, _PASSWORD, True),
+        (_HASH_STR, "INVALID_PASSWORD", False),
+        (_HASH_BYTES, "INVALID_PASSWORD", False),
+    ],
+)
+def test_verify(
+    hash: str | bytes,
+    password: str,
+    result: bool,
+    scrypt_hasher: ScryptHasher,
+) -> None:
+    assert scrypt_hasher.verify(password, hash) == result
+
+
+def test_verify_with_custom_params(scrypt_hasher_custom_params: ScryptHasher) -> None:
+    hash = scrypt_hasher_custom_params.hash(_PASSWORD)
+    assert scrypt_hasher_custom_params.verify(_PASSWORD, hash)
+    assert not scrypt_hasher_custom_params.verify("wrong", hash)
+
+
+def test_verify_invalid_hash_format(scrypt_hasher: ScryptHasher) -> None:
+    assert not scrypt_hasher.verify(_PASSWORD, "INVALID_HASH")
+    assert not scrypt_hasher.verify(_PASSWORD, b"INVALID_HASH")
+
+
+def test_check_needs_rehash(scrypt_hasher: ScryptHasher) -> None:
+    # Hash with default params should not need rehash
+    hash = scrypt_hasher.hash(_PASSWORD)
+    assert not scrypt_hasher.check_needs_rehash(hash)
+    assert not scrypt_hasher.check_needs_rehash(hash.encode("ascii"))
+
+
+def test_check_needs_rehash_different_params(scrypt_hasher: ScryptHasher, scrypt_hasher_custom_params: ScryptHasher) -> None:
+    # Hash with custom params should need rehash when checked with default params
+    hash = scrypt_hasher_custom_params.hash(_PASSWORD)
+    assert scrypt_hasher.check_needs_rehash(hash)
+
+
+def test_check_needs_rehash_invalid_format(scrypt_hasher: ScryptHasher) -> None:
+    assert scrypt_hasher.check_needs_rehash("INVALID_HASH")
+    assert scrypt_hasher.check_needs_rehash(b"INVALID_HASH")
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        pytest.param(123, id="int"),
+        pytest.param(None, id="None"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ],
+)
+def test_invalid_type(invalid_value: object, scrypt_hasher: ScryptHasher) -> None:
+    with pytest.raises(TypeError, match="hash must be str or bytes"):
+        ScryptHasher.identify(invalid_value)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="password must be str or bytes"):
+        scrypt_hasher.hash(invalid_value)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="password must be str or bytes"):
+        scrypt_hasher.verify(invalid_value, _HASH_STR)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="hash must be str or bytes"):
+        scrypt_hasher.verify(_PASSWORD, invalid_value)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="hash must be str or bytes"):
+        scrypt_hasher.check_needs_rehash(invalid_value)  # type: ignore[arg-type]
+
+
+def test_hash_format(scrypt_hasher: ScryptHasher) -> None:
+    """Test that the hash format matches the expected pattern."""
+    hash = scrypt_hasher.hash(_PASSWORD)
+    parts = hash.split("$")
+
+    # Format: $scrypt$N$salt$r$p$hash (Django-style)
+    # Note: parts[0] is empty, parts[1] is 'scrypt', parts[2] is N,
+    # parts[3] is salt (base64), parts[4] is r, parts[5] is p, parts[6] is hash (base64)
+    assert len(parts) == 7
+    assert parts[0] == ""
+    assert parts[1] == "scrypt"
+    assert parts[2] == str(scrypt_hasher.n)  # N parameter
+    assert parts[4] == str(scrypt_hasher.r)  # r parameter
+    assert parts[5] == str(scrypt_hasher.p)  # p parameter
+
+    # Check that salt and hash are valid base64
+    salt_b64 = parts[3]
+    hash_b64 = parts[6]
+
+    # The salt should be base64 decodable
+    salt = base64.b64decode(salt_b64)
+    assert len(salt) == scrypt_hasher.salt_len
+
+
+def test_verify_manual_hash(scrypt_hasher: ScryptHasher) -> None:
+    """Test verification with a manually constructed hash."""
+    password = "test123"
+    salt = b"manuelsalt1234"
+
+    # Create hash manually
+    derived_key = hashlib.scrypt(
+        password=password.encode("utf-8"),
+        salt=salt,
+        n=scrypt_hasher.n,
+        r=scrypt_hasher.r,
+        p=scrypt_hasher.p,
+        dklen=scrypt_hasher.hash_len,
+    )
+
+    # Use standard base64 with padding (Django-style)
+    salt_b64 = base64.b64encode(salt).decode("ascii")
+    hash_b64 = base64.b64encode(derived_key).decode("ascii")
+    manual_hash = f"$scrypt${scrypt_hasher.n}${salt_b64}${scrypt_hasher.r}${scrypt_hasher.p}${hash_b64}"
+
+    assert scrypt_hasher.verify(password, manual_hash)
+    assert not scrypt_hasher.verify("wrong", manual_hash)


### PR DESCRIPTION
Add a new ScryptHasher class that follows the same pattern as Argon2Hasher and BcryptHasher.

Features:
- Uses Python's builtin hashlib.scrypt (no external dependencies)
- Follows OWASP recommendations for parameters (N=2^14, r=8, p=1)
- Implements Django-compatible hash format: $<N>$<salt>$<r>$<p>$<hash>
- Full test coverage (26 new tests)

See: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#scrypt