### PR TITLE
Use Self instead of class name for type hints

### DIFF
--- a/pwdlib/_hash.py
+++ b/pwdlib/_hash.py
@@ -1,8 +1,17 @@
 import collections.abc
+from typing import TYPE_CHECKING
 
 from . import exceptions
 from .hashers import HasherProtocol
 from .hashers.base import validate_str_or_bytes
+
+if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 
 class PasswordHash:
@@ -23,7 +32,7 @@ class PasswordHash:
         self.current_hasher = hashers[0]
 
     @classmethod
-    def recommended(cls) -> "PasswordHash":
+    def recommended(cls) -> "Self":
         """
         Returns a PasswordHash instance with recommended hashers.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "pytest-cov",
     "mkdocs-material",
     "mkdocstrings[python]",
+    "typing-extensions",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -860,6 +860,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "typing-extensions" },
 ]
 
 [package.metadata]
@@ -877,6 +878,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "typing-extensions" },
 ]
 
 [[package]]


### PR DESCRIPTION
Consider the following code snippet:
```
# demo.py
from pwdlib import PasswordHash


class MyPasswordHash(PasswordHash):
    pass


def do_sth(hasher: MyPasswordHash) -> None:
    print(hasher)


do_sth(MyPasswordHash.recommended())
```

Running `mypy demo.py` produces:

```
demo.py:12: error: Argument 1 to "do_sth" has incompatible type "PasswordHash"; expected "MyPasswordHash"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```
This PR resolves the issue.

