### PR TITLE
Remove argon2-cffi top-pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 
 [project.optional-dependencies]
 argon2 = [
-    "argon2-cffi >=23.1.0,<26",
+    "argon2-cffi >=23.1.0",
 ]
 bcrypt = [
     "bcrypt >=4.1.2,<6",

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -864,7 +864,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "argon2-cffi", marker = "extra == 'argon2'", specifier = ">=23.1.0,<26" },
+    { name = "argon2-cffi", marker = "extra == 'argon2'", specifier = ">=23.1.0" },
     { name = "bcrypt", marker = "extra == 'bcrypt'", specifier = ">=4.1.2,<6" },
 ]
 provides-extras = ["argon2", "bcrypt"]


### PR DESCRIPTION
Hi,

I'm the maintainer of argon2-cffi. Kudos for trying to drag something resembling passlib into 2026!

This change removes the argon2-cffi top-pin because argon2-cffi doesn't use SemVer, but [CalVer](https://calver.org). All this pin does is preventing updates to versions released after 01.01.2026. We have a very generous backwards-compatibility policy, too: https://github.com/hynek/argon2-cffi/blob/main/.github/SECURITY.md

I would be remiss to fail to link to Henry's piece on top-pins even for SemVer projects: https://iscinumpy.dev/post/bound-version-constraints/

Cheers,
—h